### PR TITLE
Opt out of Google's FLoC Network 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,5 @@ RUN vnu-runtime-image/bin/vnu --verbose --errors-only $(cat /tmp/html)
 
 # Execution stage
 FROM nginx:stable-alpine
+COPY nginx.conf /etc/nginx/nginx.conf
 COPY --from=build /build/public /usr/share/nginx/html

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,57 @@
+user nginx;
+worker_processes auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+	worker_connections  1024;
+}
+
+http {
+	include       /etc/nginx/mime.types;
+	default_type  application/octet-stream;
+
+	log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+		'$status $body_bytes_sent "$http_referer" '
+		'"$http_user_agent" "$http_x_forwarded_for"';
+
+	access_log  /var/log/nginx/access.log  main;
+
+	sendfile    on;
+#tcp_nopush on;
+
+	keepalive_timeout 65;
+
+# gzip settings
+	gzip on;
+	gzip_disable "msie6";
+
+	gzip_vary on;
+	gzip_proxied any;
+	gzip_comp_level 6;
+	gzip_buffers 16 8k;
+	gzip_http_version 1.1;
+	gzip_min_length 256;
+	gzip_types
+		application/atom+xml
+		application/javascript
+		application/json
+		application/rss+xml
+		font/eot
+		font/otf
+		font/ttf
+		image/svg+xml
+		text/css
+		text/html
+		text/plain;
+# end gzip
+
+	server {
+		listen 80;
+
+		location / {
+			root /usr/share/nginx/html;
+		}
+	}
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,11 +19,11 @@ http {
 	access_log  /var/log/nginx/access.log  main;
 
 	sendfile    on;
-#tcp_nopush on;
+	#tcp_nopush on;
 
 	keepalive_timeout 65;
 
-# gzip settings
+	# gzip settings
 	gzip on;
 	gzip_disable "msie6";
 
@@ -45,12 +45,13 @@ http {
 		text/css
 		text/html
 		text/plain;
-# end gzip
+	# end gzip
 
 	server {
 		listen 80;
 
 		location / {
+			# https://paramdeo.com/blog/opting-your-website-out-of-googles-floc-network
 			add_header Permissions-Policy interest-cohort=();
 			root /usr/share/nginx/html;
 		}

--- a/nginx.conf
+++ b/nginx.conf
@@ -51,6 +51,7 @@ http {
 		listen 80;
 
 		location / {
+			add_header Permissions-Policy interest-cohort=();
 			root /usr/share/nginx/html;
 		}
 	}


### PR DESCRIPTION
Adds an explicit nginx configuration to set the FLoC opt-out header. Also turns on `gzip`.

> The primary way an end-user can avoid being FLoC’d is to simply not use Chrome, and instead choose a privacy-respecting browser such as Mozilla Firefox .
>
> But website owners can also ensure that their web servers are not participating in this massive network by opting-out of FLoC.
>
> To do so, the following custom HTTP response header needs to be added:
>
> ```
> Permissions-Policy: interest-cohort=()
> ```
> https://paramdeo.com/blog/opting-your-website-out-of-googles-floc-network